### PR TITLE
fix(travis-template): update travis template

### DIFF
--- a/src/templates/core/.travis.yml
+++ b/src/templates/core/.travis.yml
@@ -5,7 +5,9 @@ cache:
 notifications:
   email: true
 node_js:
-  - '8'
+  - 'node'
+  - 'lts/*'
+install: npm install
 before_install:
   - npm install -g npm@5
   - npm install -g greenkeeper-lockfile@1


### PR DESCRIPTION
Specify latest stable Node.js release
Specify latest LTS Node.js release
Specify install command as npm install because greenkeeper-lockfile fails for npm ci